### PR TITLE
Undelegations for epoch and cursor based pagination of list of delegations for a contract

### DIFF
--- a/apps/delegation-api/src/common/services/cache-manager/cache-manager.service.ts
+++ b/apps/delegation-api/src/common/services/cache-manager/cache-manager.service.ts
@@ -7,6 +7,7 @@ import { UserContractDeploy } from '../../../models';
 import { AddressActiveContract } from '../../../models/address-active-contract';
 import { ContractFeeChanges } from '../../../models/contract-fee-changes';
 import { NetworkConfig, NetworkStatus } from '@elrondnetwork/erdjs-network-providers';
+import { Constants } from '@elrondnetwork/erdnest/lib/src/utils/constants';
 
 const Keys = {
   allContractAddresses: () => 'allContractAddresses',
@@ -35,6 +36,7 @@ const Keys = {
   isContractDeployedByAddress: (contract: string, address: string) => `isContractDeployedByAddress.${contract}.${address}`,
   addressContractDeploys: () => 'addressContractDeploys',
   addressActiveContracts: (address: string) => `addressActiveContracts.${address}`,
+  totalUndelegatingAddressesForContract: (contract: string) => `totalUndelegatingAddressesByEpoch.${contract}`,
 };
 
 @Injectable()
@@ -333,6 +335,12 @@ export class CacheManagerService {
   }
   async setContractFeeChange(forContract: string, data: ContractFeeChanges): Promise<void> {
     await this.set(Keys.contractFeeChanges(forContract), data, cacheConfig.getContractFeeChanges);
+  }
+  async setTotalUndelegatingAddressesForContract(contract: string, totalForEpochs: number[]): Promise<void> {
+    await this.set(Keys.totalUndelegatingAddressesForContract(contract), totalForEpochs, Constants.oneDay());
+  }
+  getTotalUndelegatingAddressesForContract(contract: string): Promise<number[]> {
+    return this.cacheManager.get(Keys.totalUndelegatingAddressesForContract(contract));
   }
 
   private set(key: string, value: any, ttl: number) {

--- a/apps/delegation-api/src/common/services/cache-warmer/cache-warmer.module.ts
+++ b/apps/delegation-api/src/common/services/cache-warmer/cache-warmer.module.ts
@@ -3,6 +3,8 @@ import { CacheWarmerService } from './cache-warmer.service';
 import { ElrondCommunicationModule } from '../elrond-communication/elrond-communication.module';
 import { CacheManagerModule } from '../cache-manager/cache-manager.module';
 import { CacheWarmerScheduler } from './cache-warmer.scheduler';
+import { UserUndelegatedListModule } from '../user-undelegated-list/user-undelegated-list.module';
+import { ProviderManagerModule } from '../provider-manager/provider-manager.module';
 
 @Module({
   providers: [
@@ -12,6 +14,8 @@ import { CacheWarmerScheduler } from './cache-warmer.scheduler';
   imports: [
     ElrondCommunicationModule,
     CacheManagerModule,
+    UserUndelegatedListModule,
+    ProviderManagerModule,
   ],
   exports: [
     CacheWarmerService,

--- a/apps/delegation-api/src/common/services/cache-warmer/cache-warmer.scheduler.ts
+++ b/apps/delegation-api/src/common/services/cache-warmer/cache-warmer.scheduler.ts
@@ -10,4 +10,9 @@ export class CacheWarmerScheduler {
   async maintainStakingContractDeployedContracts() {
     await this.cacheWarmerService.cacheStakingContractDeployedContracts();
   }
+
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async maintainPendingUndelegations() {
+    await this.cacheWarmerService.getPendingUndelegations();
+  }
 }

--- a/apps/delegation-api/src/common/services/cache-warmer/cache-warmer.service.ts
+++ b/apps/delegation-api/src/common/services/cache-warmer/cache-warmer.service.ts
@@ -17,7 +17,6 @@ export class CacheWarmerService implements OnModuleInit {
   { }
 
   async onModuleInit() {
-    await this.getPendingUndelegations();
     await this.cacheStakingContractDeployedContracts();
   }
 

--- a/apps/delegation-api/src/common/services/cache-warmer/cache-warmer.service.ts
+++ b/apps/delegation-api/src/common/services/cache-warmer/cache-warmer.service.ts
@@ -2,16 +2,22 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ElrondElasticService } from '../elrond-communication/elrond-elastic.service';
 import { UserContractDeploy } from '../../../models';
 import { CacheManagerService } from '../cache-manager/cache-manager.service';
+import { UserUndelegatedListService } from '../user-undelegated-list/user-undelegated-list.service';
+import { ProviderManagerService } from '../provider-manager/provider-manager.service';
 
 @Injectable()
 export class CacheWarmerService implements OnModuleInit {
 
   constructor(
     private readonly elasticService: ElrondElasticService,
-    private readonly cacheManager: CacheManagerService) {
-  }
+    private readonly cacheManager: CacheManagerService,
+    private readonly userUndelegatedListService: UserUndelegatedListService,
+    private readonly providerManagerService: ProviderManagerService,
+  )
+  { }
 
   async onModuleInit() {
+    await this.getPendingUndelegations();
     await this.cacheStakingContractDeployedContracts();
   }
 
@@ -29,5 +35,37 @@ export class CacheWarmerService implements OnModuleInit {
     });
 
     await this.cacheManager.setAddressContractDeploys(userContractMap);
+  }
+
+  async getPendingUndelegations() {
+    const providerAddresses = await this.providerManagerService.getAllContractAddresses();
+    for (const contract of providerAddresses) {
+      await this.getPendingUndelegationsForContract(contract);
+    }
+  }
+
+  async getPendingUndelegationsForContract(contract: string) {
+    let data;
+    const totalForEpochs: number[] = [0,0,0,0,0,0,0,0,0,0];
+    do {
+      data = await this.elasticService.getDelegationsForContractWithCursor(contract, data?.cursor);
+      if (!data){
+        continue;
+      }
+      for(const stakingData of data.items) {
+        const userUndelegatedList = await this.userUndelegatedListService.get(contract, stakingData.address, true);
+        if (!userUndelegatedList) {
+          continue;
+        }
+        for (const listItem of userUndelegatedList) {
+          if (listItem.remainingEpochsNumber >= totalForEpochs.length) {
+            continue;
+          }
+          totalForEpochs[listItem.remainingEpochsNumber]++;
+        }
+      }
+    } while (data);
+
+    await this.cacheManager.setTotalUndelegatingAddressesForContract(contract, totalForEpochs);
   }
 }

--- a/apps/delegation-api/src/common/services/elrond-communication/elrond-elastic.service.ts
+++ b/apps/delegation-api/src/common/services/elrond-communication/elrond-elastic.service.ts
@@ -214,7 +214,7 @@ export class ElrondElasticService {
     }
   }
 
-  async getDelegationsForContractWithCursor(contract: string, cursor: string | null = null): Promise<SearchAfterResponse<AddressActiveContract> | null> {
+  async getDelegationsForContractWithCursor(contract: string, cursor = ''): Promise<SearchAfterResponse<AddressActiveContract> | null> {
     const body = {
       size: this.PAGE_SIZE,
       'query': {

--- a/apps/delegation-api/src/common/services/user-undelegated-list/user-undelegated-list.module.ts
+++ b/apps/delegation-api/src/common/services/user-undelegated-list/user-undelegated-list.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { ElrondCommunicationModule } from '../elrond-communication/elrond-communication.module';
+import { CacheManagerModule } from '../cache-manager/cache-manager.module';
+import { UserUndelegatedListService } from './user-undelegated-list.service';
+
+@Module({
+  providers: [
+    UserUndelegatedListService,
+  ],
+  imports: [
+    ElrondCommunicationModule,
+    CacheManagerModule,
+  ],
+  exports: [
+    UserUndelegatedListService,
+  ],
+})
+export class UserUndelegatedListModule {}

--- a/apps/delegation-api/src/common/services/user-undelegated-list/user-undelegated-list.service.ts
+++ b/apps/delegation-api/src/common/services/user-undelegated-list/user-undelegated-list.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@nestjs/common';
+import { ElrondProxyService } from '../elrond-communication/elrond-proxy.service';
+import { UserUndelegatedItem } from '../../../models/user-undelegated-list.dto';
+import { CacheManagerService } from '../cache-manager/cache-manager.service';
+
+@Injectable()
+export class UserUndelegatedListService {
+
+  constructor(
+    private elrondProxyService: ElrondProxyService,
+    private cacheManagerService: CacheManagerService,
+  )
+  { }
+
+  async get(contract: string, address: string, withRemainingEpochs= false): Promise<UserUndelegatedItem[] | null> {
+    try {
+      const scResponse = await this.elrondProxyService.getUserUnDelegatedList(
+        address,
+        contract
+      );
+
+      if (!scResponse.returnData || scResponse.returnData.length === 0) {
+        return null;
+      }
+
+      const networkConfig = await this.elrondProxyService.getNetworkConfig();
+      const networkStatus = await this.elrondProxyService.getNetworkStatus();
+      if (!networkConfig.RoundsPerEpoch) {
+        networkConfig.RoundsPerEpoch = networkStatus.RoundsPerEpoch;
+      }
+
+      const undelegatedList = scResponse.getReturnDataParts();
+      const results = [];
+      for(let index = 0; index < undelegatedList.length - 1; index = index + 2) {
+        const undelegatedAmountBuffer = undelegatedList[index];
+        const remainingEpochsBuffer = undelegatedList[index + 1];
+        const remainingEpochsNumber = remainingEpochsBuffer.asNumber();
+        const amount = undelegatedAmountBuffer.asFixed();
+        const cachedExpireTime = await this.cacheManagerService.getUndelegatedExpireTime(
+          address,
+          contract,
+          amount,
+          remainingEpochsNumber,
+          networkStatus.EpochNumber);
+
+        if (!!cachedExpireTime) {
+          // if there is a cached expire time calculate seconds and add them to the returned object
+          const expireDateTime = Date.parse(cachedExpireTime);
+          const currentDate = new Date();
+          let cachedSecondsLeft = Math.round((expireDateTime - currentDate.getTime()) / 1000);
+          if (cachedSecondsLeft < 0) {
+            cachedSecondsLeft = 0;
+          }
+          const undelegatedItem = new UserUndelegatedItem(
+            amount,
+            cachedSecondsLeft,
+          );
+          if (withRemainingEpochs) {
+            undelegatedItem.remainingEpochsNumber = remainingEpochsNumber;
+          }
+          results.push(undelegatedItem);
+          continue;
+        }
+
+        const secondsLeft = this.calculateUndelegatedSecondsLeft(
+          networkConfig.RoundsPerEpoch,
+          networkConfig.RoundDuration,
+          networkStatus.RoundsPassedInCurrentEpoch,
+          remainingEpochsNumber
+        );
+
+        const expireDate = new Date();
+        expireDate.setSeconds(expireDate.getSeconds() + secondsLeft);
+        // cache expireDate, so we can calculate secondsLeft on future requests, when no new data will be fetched from
+        // vm-query.
+        await this.cacheManagerService.setUndelegatedExpireTime(
+          address,
+          contract,
+          amount,
+          remainingEpochsNumber,
+          networkStatus.EpochNumber,
+          expireDate.toString());
+
+        const undelegatedItem = new UserUndelegatedItem(
+          amount,
+          secondsLeft,
+        );
+        if (withRemainingEpochs) {
+          undelegatedItem.remainingEpochsNumber = remainingEpochsNumber;
+        }
+        results.push(undelegatedItem);
+
+      }
+
+      return results;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  private calculateUndelegatedSecondsLeft(
+    roundsPerEpoch: number,
+    roundDuration: number,
+    roundsPassedInCurrentEpoch: number,
+    remainingEpochs: number): number {
+    let roundsCurrentEpoch = roundsPerEpoch - roundsPassedInCurrentEpoch;
+    if (roundsCurrentEpoch < 0) roundsCurrentEpoch = 0;
+    let roundsCompletedEpochs = 0;
+    let secondsLeft: number;
+    if (remainingEpochs >= 1) {
+      roundsCompletedEpochs = (remainingEpochs - 1) * roundsPerEpoch;
+      const totalRounds = roundsCurrentEpoch + roundsCompletedEpochs;
+      secondsLeft = totalRounds * roundDuration / 1000;
+    } else {
+      secondsLeft = 0;
+    }
+
+    return secondsLeft;
+  }
+}

--- a/apps/delegation-api/src/models/index.ts
+++ b/apps/delegation-api/src/models/index.ts
@@ -2,3 +2,4 @@ export * from '../common/errors';
 export * from './caching-config';
 export * from './contract-deploy-tx';
 export * from './elastic-transaction';
+export * from './search-after-response';

--- a/apps/delegation-api/src/models/search-after-response.ts
+++ b/apps/delegation-api/src/models/search-after-response.ts
@@ -1,0 +1,9 @@
+export class SearchAfterResponse<T> {
+  items: T[];
+  cursor?: string;
+
+  constructor(items: T[], cursor: string) {
+    this.items = items;
+    this.cursor = cursor;
+  }
+}

--- a/apps/delegation-api/src/models/user-undelegated-list.dto.ts
+++ b/apps/delegation-api/src/models/user-undelegated-list.dto.ts
@@ -13,7 +13,7 @@ export class UserUndelegatedListDto {
 export class UserUndelegatedItem {
   amount: string;
   seconds: number;
-
+  remainingEpochsNumber?: number;
 
   constructor(amount: string, seconds: number) {
     this.amount = amount;

--- a/apps/delegation-api/src/modules/delegation/delegation.module.ts
+++ b/apps/delegation-api/src/modules/delegation/delegation.module.ts
@@ -5,6 +5,7 @@ import { DelegationService } from './delegation.service';
 import { CacheManagerModule } from '../../common/services/cache-manager/cache-manager.module';
 import { ProvidersModule } from '../providers/providers.module';
 import * as redisStore from 'cache-manager-ioredis';
+import { UserUndelegatedListModule } from '../../common/services/user-undelegated-list/user-undelegated-list.module';
 
 @Module({
   controllers: [DelegationController],
@@ -25,6 +26,7 @@ import * as redisStore from 'cache-manager-ioredis';
       }],
       name: process.env.SENTINEL_NAME,
     }),
+    UserUndelegatedListModule,
   ],
   exports: [
     DelegationService,

--- a/apps/delegation-api/src/modules/delegation/dto/delegation.dto.ts
+++ b/apps/delegation-api/src/modules/delegation/dto/delegation.dto.ts
@@ -1,4 +1,4 @@
-import { UserUndelegatedItem } from './user-undelegated-list.dto';
+import { UserUndelegatedItem } from '../../../models/user-undelegated-list.dto';
 
 export class Delegation {
   address: string;

--- a/apps/delegation-api/src/modules/providers/dto/pending-undelegations.dto.ts
+++ b/apps/delegation-api/src/modules/providers/dto/pending-undelegations.dto.ts
@@ -1,0 +1,9 @@
+export class PendingUndelegationsDto {
+  contract: string;
+  epoch: number[];
+
+  constructor(contract: string, epoch: number[]) {
+    this.contract = contract;
+    this.epoch = epoch;
+  }
+}

--- a/apps/delegation-api/src/modules/providers/dto/provider-delegations-with-cursor.ts
+++ b/apps/delegation-api/src/modules/providers/dto/provider-delegations-with-cursor.ts
@@ -1,0 +1,11 @@
+import { ProviderDelegation } from './provider-delegation.dto';
+
+export class ProviderDelegationsWithCursor {
+  delegations: ProviderDelegation[];
+  cursor: string;
+
+  constructor(delegations: ProviderDelegation[], cursor: string) {
+    this.delegations = delegations;
+    this.cursor = cursor;
+  }
+}

--- a/apps/delegation-api/src/modules/providers/providers-v2.controller.ts
+++ b/apps/delegation-api/src/modules/providers/providers-v2.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, DefaultValuePipe, Get, Param, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ProvidersService } from './providers.service';
+import { ProviderDelegationsWithCursor } from './dto/provider-delegations-with-cursor';
+import { PendingUndelegationsDto } from './dto/pending-undelegations.dto';
+
+@Controller('v2/providers')
+@ApiTags('Providers V2')
+export class ProvidersControllerV2 {
+
+  constructor(private providersService: ProvidersService) {}
+
+  @Get('pending-undelegations')
+  @ApiOkResponse({
+    description: 'The pending number of undelegations for each provider and epoch',
+    type: [PendingUndelegationsDto],
+  })
+  pendingDelegations() : Promise<PendingUndelegationsDto[]> {
+    return this.providersService.getPendingUndelegations();
+  }
+
+  @Get(':provider/delegations')
+  @ApiQuery({
+    name: 'cursor',
+    type: 'string',
+    required: false,
+  })
+  @ApiOkResponse({
+    description: 'The Delegation list for this provider paginated by use of a cursor',
+    type: ProviderDelegationsWithCursor,
+  })
+  stakingProviderDelegationsByCursor(
+    @Param('provider') provider: string,
+    @Query('cursor', new DefaultValuePipe('')) cursor: string,
+  ) : Promise<ProviderDelegationsWithCursor> {
+    return this.providersService.getProviderDelegationsByCursor(provider, cursor);
+  }
+}

--- a/apps/delegation-api/src/modules/providers/providers.controller.ts
+++ b/apps/delegation-api/src/modules/providers/providers.controller.ts
@@ -4,6 +4,7 @@ import { Provider } from './dto/providers.response.dto';
 import { ProvidersService } from './providers.service';
 import { ProviderDelegation } from './dto/provider-delegation.dto';
 import { PagePipe } from '../../common/utils/pipes/page.pipe';
+import { ProviderDelegationsWithCursor } from './dto/provider-delegations-with-cursor';
 
 @Controller('providers')
 @ApiTags('Providers')
@@ -53,5 +54,22 @@ export class ProvidersController {
     @Query('page', new DefaultValuePipe(1), new ParseIntPipe(), new PagePipe()) page: number,
   ) : Promise<ProviderDelegation[]> {
     return this.providersService.getProviderDelegations(provider, page);
+  }
+
+  @Get(':provider/stakers')
+  @ApiQuery({
+    name: 'cursor',
+    type: 'string',
+    required: false,
+  })
+  @ApiOkResponse({
+    description: 'The Delegation list for this provider paginated by use of a cursor',
+    type: ProviderDelegationsWithCursor,
+  })
+  stakingProviderDelegationsByCursor(
+    @Param('provider') provider: string,
+    @Query('cursor', new DefaultValuePipe('')) cursor: string,
+  ) : Promise<ProviderDelegationsWithCursor> {
+    return this.providersService.getProviderDelegationsByCursor(provider, cursor);
   }
 }

--- a/apps/delegation-api/src/modules/providers/providers.module.ts
+++ b/apps/delegation-api/src/modules/providers/providers.module.ts
@@ -6,9 +6,10 @@ import { ElrondCommunicationModule } from '../../common/services/elrond-communic
 import { ProviderManagerModule } from '../../common/services/provider-manager/provider-manager.module';
 import { DelegationAprService } from '../delegation/delegation-apr.service';
 import { ServicesModule } from '../../common/services';
+import { ProvidersControllerV2 } from './providers-v2.controller';
 
 @Module({
-  controllers: [ProvidersController],
+  controllers: [ProvidersController, ProvidersControllerV2],
   providers: [
     ProvidersService,
     DelegationAprService,

--- a/apps/delegation-api/src/modules/providers/providers.service.ts
+++ b/apps/delegation-api/src/modules/providers/providers.service.ts
@@ -19,6 +19,8 @@ import asyncPool from 'tiny-async-pool';
 import { elrondConfig } from '../../config';
 import { ElrondElasticService } from '../../common/services/elrond-communication/elrond-elastic.service';
 import { ProviderDelegation } from './dto/provider-delegation.dto';
+import { ProviderDelegationsWithCursor } from './dto/provider-delegations-with-cursor';
+import { PendingUndelegationsDto } from './dto/pending-undelegations.dto';
 
 @Injectable()
 export class ProvidersService {
@@ -106,6 +108,14 @@ export class ProvidersService {
       return [];
     }
     return delegations.map(e => ProviderDelegation.fromAddressActiveContract(e));
+  }
+
+  async getProviderDelegationsByCursor(provider: string, cursor: string): Promise<ProviderDelegationsWithCursor> {
+    const data =  await this.elrondElasticService.getDelegationsForContractWithCursor(provider, cursor);
+    if (!data) {
+      return new ProviderDelegationsWithCursor([], '');
+    }
+    return new ProviderDelegationsWithCursor(data.items.map(e => ProviderDelegation.fromAddressActiveContract(e)), data.cursor);
   }
 
   private async getProvidersForApi(providers: ProviderWithData[]): Promise<Provider[]> {
@@ -259,5 +269,15 @@ export class ProvidersService {
         error: ErrorCodes.errorCallingContract,
       });
     }
+  }
+
+  async getPendingUndelegations(): Promise<PendingUndelegationsDto[]>{
+    const providerAddresses = await this.providerManager.getAllContractAddresses();
+    return await Promise.all(
+      providerAddresses.map(async e => new PendingUndelegationsDto(
+        e,
+        await this.cacheManagerService.getTotalUndelegatingAddressesForContract(e)
+      ))
+    );
   }
 }


### PR DESCRIPTION
##Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)

1. Needed a way to get past 10k records for delegations for a provider
2. Wanted a list of number of undelegations that can be done each epoch

## Proposed Changes

The total addresses that can withdraw their funds for each epoch is calculated and cached. Please note that this process takes a long time and may have to be improved.

## How to test
- 
-
- 