### PR TITLE
Added /v2/providers/{provider}/delegations that uses cursor

### DIFF
--- a/apps/delegation-api/src/common/services/elrond-communication/elrond-elastic.service.ts
+++ b/apps/delegation-api/src/common/services/elrond-communication/elrond-elastic.service.ts
@@ -3,7 +3,7 @@ import { elrondConfig } from '../../../config';
 import { Client } from '@elastic/elasticsearch';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
-import { ContractDeployTx, ElasticTransaction } from '../../../models';
+import { ContractDeployTx, ElasticTransaction, SearchAfterResponse } from '../../../models';
 import { AddressActiveContract } from '../../../models/address-active-contract';
 
 /**
@@ -208,6 +208,46 @@ export class ElrondElasticService {
     } catch (e) {
       this.logger.error('Fail to getDelegationsForContract', {
         path: 'elrond-elastic.service.getDelegationsForContract',
+        exception: e.toString(),
+      });
+      throw e;
+    }
+  }
+
+  async getDelegationsForContractWithCursor(contract: string, cursor = ''): Promise<SearchAfterResponse<AddressActiveContract> | null> {
+    const body = {
+      size: this.PAGE_SIZE,
+      'query': {
+        'bool': {
+          'must': [
+            {
+              'match': {
+                'contract': contract,
+              },
+            },
+          ],
+        },
+      },
+      sort: {
+        _id: {
+          order: 'asc',
+        },
+      },
+    };
+    if (cursor) {
+      body['search_after'] = [cursor];
+    }
+
+    try {
+      const response = await this.delegatorsClient.search({ body });
+      if (response.body.hits.hits.length) {
+        return new SearchAfterResponse(response.body.hits.hits.map(e => e._source), response.body.hits.hits[response.body.hits.hits.length - 1].sort[0]);
+      } else {
+        return null;
+      }
+    } catch (e) {
+      this.logger.error('Fail to getDelegationsForContractWithCursor', {
+        path: 'elrond-elastic.service.getDelegationsForContractWithCursor',
         exception: e.toString(),
       });
       throw e;

--- a/apps/delegation-api/src/models/index.ts
+++ b/apps/delegation-api/src/models/index.ts
@@ -2,3 +2,4 @@ export * from '../common/errors';
 export * from './caching-config';
 export * from './contract-deploy-tx';
 export * from './elastic-transaction';
+export * from './search-after-response';

--- a/apps/delegation-api/src/models/search-after-response.ts
+++ b/apps/delegation-api/src/models/search-after-response.ts
@@ -1,0 +1,9 @@
+export class SearchAfterResponse<T> {
+  items: T[];
+  cursor?: string;
+
+  constructor(items: T[], cursor: string) {
+    this.items = items;
+    this.cursor = cursor;
+  }
+}

--- a/apps/delegation-api/src/modules/providers/dto/provider-delegations-with-cursor.ts
+++ b/apps/delegation-api/src/modules/providers/dto/provider-delegations-with-cursor.ts
@@ -1,0 +1,11 @@
+import { ProviderDelegation } from './provider-delegation.dto';
+
+export class ProviderDelegationsWithCursor {
+  delegations: ProviderDelegation[];
+  cursor: string;
+
+  constructor(delegations: ProviderDelegation[], cursor: string) {
+    this.delegations = delegations;
+    this.cursor = cursor;
+  }
+}

--- a/apps/delegation-api/src/modules/providers/providers-v2.controller.ts
+++ b/apps/delegation-api/src/modules/providers/providers-v2.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, DefaultValuePipe, Get, Param, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ProvidersService } from './providers.service';
+import { ProviderDelegationsWithCursor } from './dto/provider-delegations-with-cursor';
+
+@Controller('v2/providers')
+@ApiTags('Providers V2')
+export class ProvidersControllerV2 {
+
+  constructor(private providersService: ProvidersService) {}
+
+  @Get(':provider/delegations')
+  @ApiQuery({
+    name: 'cursor',
+    type: 'string',
+    required: false,
+  })
+  @ApiOkResponse({
+    description: 'The Delegation list for this provider paginated by use of a cursor',
+    type: ProviderDelegationsWithCursor,
+  })
+  stakingProviderDelegationsByCursor(
+    @Param('provider') provider: string,
+    @Query('cursor', new DefaultValuePipe('')) cursor: string,
+  ) : Promise<ProviderDelegationsWithCursor> {
+    return this.providersService.getProviderDelegationsByCursor(provider, cursor);
+  }
+}

--- a/apps/delegation-api/src/modules/providers/providers.module.ts
+++ b/apps/delegation-api/src/modules/providers/providers.module.ts
@@ -6,9 +6,10 @@ import { ElrondCommunicationModule } from '../../common/services/elrond-communic
 import { ProviderManagerModule } from '../../common/services/provider-manager/provider-manager.module';
 import { DelegationAprService } from '../delegation/delegation-apr.service';
 import { ServicesModule } from '../../common/services';
+import { ProvidersControllerV2 } from './providers-v2.controller';
 
 @Module({
-  controllers: [ProvidersController],
+  controllers: [ProvidersController, ProvidersControllerV2],
   providers: [
     ProvidersService,
     DelegationAprService,

--- a/apps/delegation-api/src/modules/providers/providers.service.ts
+++ b/apps/delegation-api/src/modules/providers/providers.service.ts
@@ -19,6 +19,7 @@ import asyncPool from 'tiny-async-pool';
 import { elrondConfig } from '../../config';
 import { ElrondElasticService } from '../../common/services/elrond-communication/elrond-elastic.service';
 import { ProviderDelegation } from './dto/provider-delegation.dto';
+import { ProviderDelegationsWithCursor } from './dto/provider-delegations-with-cursor';
 
 @Injectable()
 export class ProvidersService {
@@ -106,6 +107,14 @@ export class ProvidersService {
       return [];
     }
     return delegations.map(e => ProviderDelegation.fromAddressActiveContract(e));
+  }
+
+  async getProviderDelegationsByCursor(provider: string, cursor: string): Promise<ProviderDelegationsWithCursor> {
+    const data =  await this.elrondElasticService.getDelegationsForContractWithCursor(provider, cursor);
+    if (!data) {
+      return new ProviderDelegationsWithCursor([], '');
+    }
+    return new ProviderDelegationsWithCursor(data.items.map(e => ProviderDelegation.fromAddressActiveContract(e)), data.cursor);
   }
 
   private async getProvidersForApi(providers: ProviderWithData[]): Promise<Provider[]> {


### PR DESCRIPTION
##Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)

We needed a method that gets us more than 10k records for a provider delegations.

## Proposed Changes

added /v2/providers/{provider}/delegations that uses cursor to get more than 10k records from elasticsearch

## How to test
- 
-
- 